### PR TITLE
Add "Abstract Types" section to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,37 @@ type animal = Dog(string) | Cat | Mouse;
 type animal = Dog(string, option(int)) | Cat;
 ```
 
+### Abstract Types
+
+For abstract types that you want to support, add manual serialization and deserialization functions.
+
+Make sure to list the module that provides the serialize and deserialize functions in  the `"helpers"` section of your `types.json` file:
+
+```diff
+   "version": 1,
+   "engines": {
+     "Js.Json": {
+-      "output": "src/TypesEncoder.re"
++      "output": "src/TypesEncoder.re",
++      "helpers": "EncoderHelpers"
+     }
+   },
+   "entries": [
+```
+
+Then define the serialize and deserialize functions. Here is an example of the function signatures to support a `StringMap.t('a)`:
+
+```reasonml
+/* EncoderHelpers.re */
+let serialize_StringMap____t = map => /* ... */
+let deserialize_StringMap____t = json => /* ... */
+let deserialize_StringMap____t = (migrator, json) => /* ... */
+```
+
+Here are some real-world examples:
+- [`types.json`](https://github.com/jaredly/veoluz/blob/master/types.json#L6)
+- [`helpers`](https://github.com/jaredly/veoluz/blob/master/ui/TypeHelpers.re)
+
 ## What type changes are "compatible"
 (e.g. don't require a version bump)
 


### PR DESCRIPTION
I had some difficulty understanding the following error message:
"Abstract type found, but no 'helpers' module specified for this engine"

I received this error because I had an Abstract Type in the object that I wanted
to serialize and deserialize but I didn't provide any implementations for Milk
to serialize or deserialize it.

I'm adding a section on "Abstract Types" to the Readme.md to document what I
learned from the issue and to hopefully help others and my future self.

See this thread for more information: https://github.com/jaredly/milk/issues/6